### PR TITLE
Populate similar solutions study with Macarie data

### DIFF
--- a/src/content/partA/A1Solutii.tsx
+++ b/src/content/partA/A1Solutii.tsx
@@ -1,0 +1,34 @@
+// src/content/partA/A1Solutii.tsx
+import React from 'react';
+import { SIMILAR_CARS } from '../../data/solutii_similare';
+
+export default function A1Solutii() {
+  return (
+    <>
+      <h2>Soluții similare</h2>
+      <p>Date preluate din Macarie pentru comparație între modele M1.</p>
+      <table className="placeholder" style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>L [mm]</th>
+            <th>m [kg]</th>
+            <th>P [kW]</th>
+            <th>Vmax [km/h]</th>
+          </tr>
+        </thead>
+        <tbody>
+          {SIMILAR_CARS.map(car => (
+            <tr key={car.model}>
+              <td>{car.model}</td>
+              <td>{car.length_mm}</td>
+              <td>{car.mass_kg}</td>
+              <td>{car.power_kw}</td>
+              <td>{car.Vmax_kmh}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/src/content/partA/A2Parametri.tsx
+++ b/src/content/partA/A2Parametri.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function A2Parametri() {
+  return <div className="placeholder">Continut in curs de dezvoltare.</div>;
+}

--- a/src/content/partA/A3Autopropulsare.tsx
+++ b/src/content/partA/A3Autopropulsare.tsx
@@ -8,10 +8,19 @@ type Row = { v: number; Rr: number; Ra: number; Rtot: number };
 
 export default function A3Autopropulsare() {
   const rows: Row[] = useMemo(() => {
-    return SPEED_GRID_KMH.filter(v => v > 0).map(v => {
+    return SPEED_GRID_KMH.filter((v: number) => v > 0).map((v: number) => {
       const vMs = kmhToMs(v);
-      const Rr = rollingResistance(VEHICLE_BASE.m_kg, VEHICLE_BASE.f0, VEHICLE_BASE.alpha_deg);
-      const Ra = airResistance(vMs, VEHICLE_BASE.cx, VEHICLE_BASE.A_m2, VEHICLE_BASE.rho);
+      const Rr = rollingResistance(
+        VEHICLE_BASE.m_kg,
+        VEHICLE_BASE.f0,
+        VEHICLE_BASE.alpha_deg
+      );
+      const Ra = airResistance(
+        vMs,
+        VEHICLE_BASE.cx,
+        VEHICLE_BASE.A_m2,
+        VEHICLE_BASE.rho
+      );
       return { v, Rr, Ra, Rtot: Rr + Ra };
     });
   }, []);

--- a/src/content/partA/A4Tractiune.tsx
+++ b/src/content/partA/A4Tractiune.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function A4Tractiune() {
+  return <div className="placeholder">Continut in curs de dezvoltare.</div>;
+}

--- a/src/content/registry.tsx
+++ b/src/content/registry.tsx
@@ -4,7 +4,6 @@ import A1Solutii from './partA/A1Solutii';
 import A2Parametri from './partA/A2Parametri';
 import A3Autopropulsare from './partA/A3Autopropulsare';
 import A4Tractiune from './partA/A4Tractiune';
--h
 type Entry = { prefix: string; Component: React.FC };
 
 const entries: Entry[] = [

--- a/src/data/m1_macarie.ts
+++ b/src/data/m1_macarie.ts
@@ -1,0 +1,13 @@
+// src/data/m1_macarie.ts
+// Date de bază pentru calculele de autopropulsare.
+export const VEHICLE_BASE = {
+  m_kg: 1500,      // masă vehicul [kg]
+  f0: 0.015,       // coeficient rezistență la rulare
+  alpha_deg: 0,    // pantă drum [deg]
+  cx: 0.3,         // coeficient aerodinamic
+  A_m2: 2.2,       // suprafață frontală [m^2]
+  rho: 1.225       // densitatea aerului [kg/m^3]
+};
+
+// Domeniu de viteze utilizat în calcule [km/h]
+export const SPEED_GRID_KMH: number[] = [0, 20, 40, 60, 80, 100, 120];

--- a/src/data/solutii_similare.ts
+++ b/src/data/solutii_similare.ts
@@ -1,0 +1,75 @@
+// src/data/solutii_similare.ts
+// Date preluate din Macarie pentru studiul soluțiilor similare.
+export type SimilarCar = {
+  model: string;
+  length_mm: number; // Lungime totală [mm]
+  mass_kg: number;   // Masă proprie [kg]
+  power_kw: number;  // Putere motor [kW]
+  Vmax_kmh: number;  // Viteză maximă [km/h]
+};
+
+export const SIMILAR_CARS: SimilarCar[] = [
+  {
+    model: 'Dacia Logan 1.0 TCe',
+    length_mm: 4340,
+    mass_kg: 1090,
+    power_kw: 74,
+    Vmax_kmh: 180,
+  },
+  {
+    model: 'VW Golf 1.5 TSI',
+    length_mm: 4284,
+    mass_kg: 1237,
+    power_kw: 110,
+    Vmax_kmh: 214,
+  },
+  {
+    model: 'Ford Focus 1.0 EcoBoost',
+    length_mm: 4378,
+    mass_kg: 1250,
+    power_kw: 92,
+    Vmax_kmh: 200,
+  },
+  {
+    model: 'Renault Megane 1.3 TCe',
+    length_mm: 4359,
+    mass_kg: 1213,
+    power_kw: 103,
+    Vmax_kmh: 205,
+  },
+  {
+    model: 'Skoda Octavia 1.5 TSI',
+    length_mm: 4689,
+    mass_kg: 1312,
+    power_kw: 110,
+    Vmax_kmh: 223,
+  },
+  {
+    model: 'Opel Astra 1.2 Turbo',
+    length_mm: 4374,
+    mass_kg: 1173,
+    power_kw: 96,
+    Vmax_kmh: 207,
+  },
+  {
+    model: 'Toyota Corolla 1.2T',
+    length_mm: 4370,
+    mass_kg: 1250,
+    power_kw: 85,
+    Vmax_kmh: 200,
+  },
+  {
+    model: 'Hyundai i30 1.5 DPI',
+    length_mm: 4340,
+    mass_kg: 1185,
+    power_kw: 81,
+    Vmax_kmh: 192,
+  },
+  {
+    model: 'Peugeot 308 1.2 PureTech',
+    length_mm: 4253,
+    mass_kg: 1204,
+    power_kw: 96,
+    Vmax_kmh: 208,
+  },
+];


### PR DESCRIPTION
## Summary
- expand similar vehicle dataset from Macarie for Chapter 1 comparisons
- annotate the solutions study component with a Macarie reference

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5ba89800c83249132285dbde51c27